### PR TITLE
Fix reading old MSbulletin file

### DIFF
--- a/sources/MSBulletin.py
+++ b/sources/MSBulletin.py
@@ -13,6 +13,7 @@
 import gzip
 import json
 import requests
+import os
 
 from collections import defaultdict
 
@@ -20,7 +21,8 @@ from lib.Source import Source
 
 SOURCE_NAME = "msbulletin"
 SOURCE_FILE = "https://portal.msrc.microsoft.com/api/security-guidance/en-us/"
-GZIP_FILE   = "./data/old_Microsoft_bulletins.gz"
+CURRENT_PATH = os.path.dirname(os.path.realpath(__file__))
+GZIP_FILE   = os.path.join(CURRENT_PATH,"../data/old_Microsoft_bulletins.gz")
 
 def get_Old_Bulletins():
     try:


### PR DESCRIPTION
Hi,
I fix reading MSBulletin file,
When you run via4cve.py in the current path, the old MSbulletin is read without problems, but if you run via4cve.py from the outside of your own folder, can't read file.

$ python3 ~/via4/VIA4CVE/via4cve.py 
[+] Loaded plugin ExploitDB
Could not read old Bulletins
[+] Loaded plugin MSBulletin
[+] Loaded plugin RedHatInfo
[+] Loaded plugin OVAL
